### PR TITLE
feat(settings): made it scrollable

### DIFF
--- a/src/gui/views/settings.rs
+++ b/src/gui/views/settings.rs
@@ -9,7 +9,9 @@ use crate::gui::style;
 use crate::gui::views::list::PackageInfo;
 use crate::gui::widgets::package_row::PackageRow;
 
-use iced::widget::{button, checkbox, column, container, pick_list, radio, row, text, Space};
+use iced::widget::{
+    button, checkbox, column, container, pick_list, radio, row, scrollable, text, Space,
+};
 use iced::{alignment, Alignment, Command, Element, Length, Renderer};
 use std::path::PathBuf;
 
@@ -418,7 +420,7 @@ impl Settings {
             .spacing(20)
         };
 
-        container(content)
+        container(scrollable(content))
             .padding(10)
             .width(Length::Fill)
             .height(Length::Fill)


### PR DESCRIPTION
Fixes #116.

Continuing from https://github.com/Universal-Debloater-Alliance/universal-android-debloater/pull/97#issuecomment-1868580290.

When content exceeds window height:
![image](https://github.com/Universal-Debloater-Alliance/universal-android-debloater/assets/14949823/7206e08f-ac4a-4984-997b-989a771c4fd7)

When content fits within window:
![image](https://github.com/Universal-Debloater-Alliance/universal-android-debloater/assets/14949823/abd67339-eb4d-4116-8dbf-3442f9978f39)
