### PR TITLE
[CHG] Move the "com.miui.miinput" package to the "Advanced" category.

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -28286,8 +28286,8 @@
   },
   {
     "id": "com.miui.miinput",
-    "description": "Only for Chinese. Also has duplicated settings activities, gestures.",
-    "removal": "Recommended",
+    "description": "Removing this package breaks \"Gesture shortcuts\" under \"Additional settings\".",
+    "removal": "Advanced",
     "list": "Oem",
     "dependencies": [],
     "neededBy": [],


### PR DESCRIPTION
- Removing this `com.miui.miinput` package breaks `Gesture shortcuts` under `Additional settings`.
- The same issue has been discussed in [here](https://www.reddit.com/r/Xiaomi/comments/tpiox1/comment/jprokou/).