### PR TITLE
feat(ui): move select and deselect all actions to more intuitive checkbox

### DIFF
--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -316,10 +316,9 @@ impl List {
                     .padding(5);
 
                 let select_all_checkbox =
-                    checkbox("", self.all_selected, Message::ToggleAllSelected)
+                    checkbox("Select all", self.all_selected, Message::ToggleAllSelected)
                         .style(style::CheckBox::SettingsEnabled);
 
-                // auto aligns the select all checkbox
                 let pre_padding = Space::new(Length::Fixed(0.0), Length::Shrink);
 
                 let user_picklist = pick_list(

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -316,10 +316,20 @@ impl List {
                     .padding(5);
 
                 let select_all_checkbox =
-                    checkbox("Select all", self.all_selected, Message::ToggleAllSelected)
-                        .style(style::CheckBox::SettingsEnabled);
+                    checkbox("", self.all_selected, Message::ToggleAllSelected)
+                        .style(style::CheckBox::SettingsEnabled)
+                        .spacing(0); // no label, so remove space entirely
 
-                let col_sel_all = row![select_all_checkbox].padding(8);
+                let col_sel_all = row![tooltip(
+                    select_all_checkbox,
+                    if self.all_selected {
+                        "Deselect all"
+                    } else {
+                        "Select all"
+                    },
+                    tooltip::Position::Top,
+                )]
+                .padding(8);
 
                 let user_picklist = pick_list(
                     selected_device.user_list.clone(),
@@ -355,7 +365,7 @@ impl List {
                 ]
                 .width(Length::Fill)
                 .align_items(Alignment::Center)
-                .spacing(10)
+                .spacing(6)
                 .padding([0, 16, 0, 0]);
 
                 let packages =

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -319,7 +319,7 @@ impl List {
                     checkbox("Select all", self.all_selected, Message::ToggleAllSelected)
                         .style(style::CheckBox::SettingsEnabled);
 
-                let pre_padding = Space::new(Length::Fixed(0.0), Length::Shrink);
+                let col_sel_all = row![select_all_checkbox].padding(8);
 
                 let user_picklist = pick_list(
                     selected_device.user_list.clone(),
@@ -345,8 +345,7 @@ impl List {
                 );
 
                 let control_panel = row![
-                    pre_padding,
-                    select_all_checkbox,
+                    col_sel_all,
                     search_packages,
                     user_picklist,
                     divider,

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -14,7 +14,7 @@ use crate::gui::views::settings::Settings;
 use crate::gui::widgets::modal::Modal;
 use crate::gui::widgets::package_row::{Message as RowMessage, PackageRow};
 use iced::widget::{
-    button, column, container, horizontal_space, pick_list, radio, row, scrollable, text,
+    button, checkbox, column, container, horizontal_space, pick_list, radio, row, scrollable, text,
     text_input, tooltip, vertical_rule, Space,
 };
 use iced::{alignment, Alignment, Command, Element, Length, Renderer};
@@ -53,6 +53,7 @@ pub struct List {
     selected_removal: Option<Removal>,
     selected_list: Option<UadList>,
     selected_user: Option<User>,
+    all_selected: bool,
     pub input_value: String,
     description: String,
     selection_modal: bool,
@@ -167,6 +168,7 @@ impl List {
                         );
                     }
                 }
+                self.all_selected = selected;
                 Command::none()
             }
             Message::SearchInputChanged(letter) => {
@@ -313,6 +315,13 @@ impl List {
                     .on_input(Message::SearchInputChanged)
                     .padding(5);
 
+                let select_all_checkbox =
+                    checkbox("", self.all_selected, Message::ToggleAllSelected)
+                        .style(style::CheckBox::SettingsEnabled);
+
+                // auto aligns the select all checkbox
+                let pre_padding = Space::new(Length::Fixed(0.0), Length::Shrink);
+
                 let user_picklist = pick_list(
                     selected_device.user_list.clone(),
                     self.selected_user,
@@ -337,6 +346,8 @@ impl List {
                 );
 
                 let control_panel = row![
+                    pre_padding,
+                    select_all_checkbox,
                     search_packages,
                     user_picklist,
                     divider,
@@ -389,25 +400,10 @@ impl List {
                     .padding(5)
                 };
 
-                let select_all_btn = button("Select all")
-                    .padding(5)
-                    .on_press(Message::ToggleAllSelected(true))
-                    .style(style::Button::Primary);
-
-                let unselect_all_btn = button("Unselect all")
-                    .padding(5)
-                    .on_press(Message::ToggleAllSelected(false))
-                    .style(style::Button::Primary);
-
-                let action_row = row![
-                    select_all_btn,
-                    unselect_all_btn,
-                    Space::new(Length::Fill, Length::Shrink),
-                    review_selection,
-                ]
-                .width(Length::Fill)
-                .spacing(10)
-                .align_items(Alignment::Center);
+                let action_row = row![Space::new(Length::Fill, Length::Shrink), review_selection]
+                    .width(Length::Fill)
+                    .spacing(10)
+                    .align_items(Alignment::Center);
 
                 let unavailable = container(
                     column![


### PR DESCRIPTION
### Changes
- Removes "Select all" and "Unselect All" button from the bottom row
- Adds a checkbox to the top row in line with the package checkbox entries for a more intuitive "select all" and "deselect all" experience

### Screenshots

![Screenshot_20240102_081552.png](https://github.com/Universal-Debloater-Alliance/universal-android-debloater/assets/107522312/6ccf5789-2a8a-4451-9bc9-7cbe635f755b)

![Screenshot_20240102_081614.png](https://github.com/Universal-Debloater-Alliance/universal-android-debloater/assets/107522312/7255b849-ed8f-4369-89aa-121b87990d5a)


