### PR TITLE
feat: add the default styling and gap to tooltip

### DIFF
--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -328,7 +328,9 @@ impl List {
                         "Select all"
                     },
                     tooltip::Position::Top,
-                )]
+                )
+                .style(style::Container::Tooltip)
+                .gap(4)]
                 .padding(8);
 
                 let user_picklist = pick_list(


### PR DESCRIPTION
### Changes
- Adds background against tooltip text for reading ease
- Adds a little bit of gap between the checkbox and tooltip

![Screenshot_20240102_143915](https://github.com/Universal-Debloater-Alliance/universal-android-debloater/assets/107522312/df59ec17-e3d2-4969-87bf-cc68d59b199e)
