### PR TITLE
feat(ui): remove useless divider and add a tooltip for the refresh button

### DIFF
--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -311,7 +311,7 @@ impl List {
             }
             LoadingState::Ready(_) => {
                 let search_packages = text_input("Search packages...", &self.input_value)
-                    .width(160)
+                    .width(Length::Fill)
                     .on_input(Message::SearchInputChanged)
                     .padding(5);
 
@@ -340,8 +340,6 @@ impl List {
                 )
                 .width(85);
 
-                let divider = Space::new(Length::Fill, Length::Shrink);
-
                 let list_picklist =
                     pick_list(&UadList::ALL[..], self.selected_list, Message::ListSelected);
                 let package_state_picklist = pick_list(
@@ -360,7 +358,6 @@ impl List {
                     col_sel_all,
                     search_packages,
                     user_picklist,
-                    divider,
                     removal_picklist,
                     package_state_picklist,
                     list_picklist,

--- a/src/gui/widgets/navigation_menu.rs
+++ b/src/gui/widgets/navigation_menu.rs
@@ -4,7 +4,7 @@ use crate::core::update::{SelfUpdateState, SelfUpdateStatus};
 pub use crate::gui::views::about::Message as AboutMessage;
 pub use crate::gui::views::list::{List as AppsView, LoadingState as ListLoadingState};
 use crate::gui::{style, Message};
-use iced::widget::{button, container, pick_list, row, text, Space, Text};
+use iced::widget::{button, container, pick_list, row, text, tooltip, Space, Text};
 use iced::{alignment, font, Alignment, Element, Font, Length, Renderer};
 
 /// resources/assets/icons.ttf, loaded in [`crate::gui::UadGui`]
@@ -28,6 +28,10 @@ pub fn nav_menu<'a>(
     .on_press(Message::RefreshButtonPressed)
     .padding(5)
     .style(style::Button::Refresh);
+
+    let apps_refresh_tooltip = tooltip(apps_refresh_btn, "Refresh apps", tooltip::Position::Bottom)
+        .style(style::Container::Tooltip)
+        .gap(4);
 
     let reboot_btn = button("Reboot")
         .on_press(Message::RebootButtonPressed)
@@ -78,7 +82,7 @@ pub fn nav_menu<'a>(
 
     let row = match selected_device {
         Some(phone) => row![
-            apps_refresh_btn,
+            apps_refresh_tooltip,
             reboot_btn,
             pick_list(device_list, Some(phone), Message::DeviceSelected,),
             Space::new(Length::Fill, Length::Shrink),
@@ -92,7 +96,7 @@ pub fn nav_menu<'a>(
         .spacing(10),
         None => row![
             reboot_btn,
-            apps_refresh_btn,
+            apps_refresh_tooltip,
             device_list_text,
             Space::new(Length::Fill, Length::Shrink),
             uad_version_text,


### PR DESCRIPTION
### Changes
- Add a tooltip that says "Refresh apps" for the refresh symbolic button
- Remove useless divider between the search box and the remaining buttons

![Screenshot_20240103_082727](https://github.com/Universal-Debloater-Alliance/universal-android-debloater/assets/107522312/7b913b18-9f39-4c31-9742-1fad6f9c51cb)
